### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/User65k/cec_linux/compare/v0.2.0...v0.2.1) - 2026-02-08
+
+### Added
+
+- add missing Capabilities constants  ([#6](https://github.com/User65k/cec_linux/pull/6))
+
+### Other
+
+- User65k patch 1 ([#7](https://github.com/User65k/cec_linux/pull/7))
+- safe initialization for CecLogAddrs (unsafe -> Default trait) ([#5](https://github.com/User65k/cec_linux/pull/5))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cec_linux"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 description = "A pure rust library to use the HDMI-CEC linux API"
 
 repository = "https://github.com/User65k/cec_linux"


### PR DESCRIPTION



## 🤖 New release

* `cec_linux`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/User65k/cec_linux/compare/v0.2.0...v0.2.1) - 2026-02-08

### Added

- add missing Capabilities constants  ([#6](https://github.com/User65k/cec_linux/pull/6))

### Other

- User65k patch 1 ([#7](https://github.com/User65k/cec_linux/pull/7))
- safe initialization for CecLogAddrs (unsafe -> Default trait) ([#5](https://github.com/User65k/cec_linux/pull/5))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).