### PR TITLE
feat: generic HDMI vendor id

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1374,6 +1374,11 @@ impl VendorID {
      * should be disabled (CEC_S_VENDOR_ID)
      */
     pub const NONE: u32 = 0xffffffff;
+    /**
+     * Use this neutral ID (assigned to HDMI Licensing, LLC.) when a valid vendor ID
+     * is required instead of leaving it disabled.
+     */
+    pub const HDMI: u32 = 0x000c03;
 }
 
 bitflags! {


### PR DESCRIPTION
add VendorID::HDMI constant for the HDMI Licensing, LLC (0x000c03).

this  is used as the default vendor ID in the cec-ctl and other cec-related utils as a neutral/safe ID, allowing to register a valid vendor id without masquerading as a specific manufacturer, thus avoiding unintended vendor-specific behaviors on bus.