### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/User65k/cec_linux/compare/v0.2.1...v0.2.2) - 2026-02-26
+
+### Other
+
+- device polling support ([#11](https://github.com/User65k/cec_linux/pull/11))
+- CecCaps new accessors: driver, name, version ([#10](https://github.com/User65k/cec_linux/pull/10))
+- generic HDMI vendor id ([#9](https://github.com/User65k/cec_linux/pull/9))
+
 ## [0.2.1](https://github.com/User65k/cec_linux/compare/v0.2.0...v0.2.1) - 2026-02-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cec_linux"
 authors = ["User65k <15049544+User65k@users.noreply.github.com>"]
 edition = "2021"
 license = "MIT"
-version = "0.2.1"
+version = "0.2.2"
 description = "A pure rust library to use the HDMI-CEC linux API"
 
 repository = "https://github.com/User65k/cec_linux"


### PR DESCRIPTION



## 🤖 New release

* `cec_linux`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/User65k/cec_linux/compare/v0.2.1...v0.2.2) - 2026-02-26

### Other

- device polling support ([#11](https://github.com/User65k/cec_linux/pull/11))
- CecCaps new accessors: driver, name, version ([#10](https://github.com/User65k/cec_linux/pull/10))
- generic HDMI vendor id ([#9](https://github.com/User65k/cec_linux/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).